### PR TITLE
This is C++ code, not C code

### DIFF
--- a/yes.cpp
+++ b/yes.cpp
@@ -1,13 +1,14 @@
-#include <cstdio>
+#include <iostream>
+
+using namespace std;
 
 int main(int argc, char** argv) {
     while (true) {
         if (argc > 1) {
-            printf("%s\n", argv[1]);
+            cout << argv[1] << endl;
         } else {
-            printf("y\n");
+            cout << "y" << endl;
         }
     }
-
     return 0;
 }


### PR DESCRIPTION
Unlike printf, cout << endl can allow for both LF and CRLF with absolutely no change to the code. In the case of printf, if you want to compile this command for Windows, you'd have to create a Windows version with "\r\n" and a Linux version with just "\n" in lines 8 and 10.